### PR TITLE
feat(Deps): Replace crytpography with hashlib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ classifiers  = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "cryptography>=40.0.0",
     "pyzipper>=0.3.6",
 ]
 description  = "A library to gather information from ETS project files used for KNX"

--- a/requirements_production.txt
+++ b/requirements_production.txt
@@ -1,2 +1,1 @@
-cryptography==41.0.3
 pyzipper==0.3.6

--- a/xknxproject/zip/extractor.py
+++ b/xknxproject/zip/extractor.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 import base64
 from collections.abc import Iterator
 from contextlib import contextmanager
+import hashlib
 import logging
 from pathlib import Path
 import re
 from typing import IO
 from zipfile import Path as ZipPath, ZipFile, ZipInfo
 
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 import pyzipper
 
 from xknxproject.const import ETS_4_2_SCHEMA_VERSION, ETS_6_SCHEMA_VERSION
@@ -173,11 +172,13 @@ def _get_schema_version(namespace: str) -> int:
 
 def _generate_ets6_zip_password(password: str) -> bytes:
     """Generate ZIP archive password."""
+
     return base64.b64encode(
-        PBKDF2HMAC(
-            algorithm=hashes.SHA256(),
-            length=32,
+        hashlib.pbkdf2_hmac(
+            hash_name="sha256",
+            password=password.encode("utf-16-le"),
             salt=b"21.project.ets.knx.org",
             iterations=65536,
-        ).derive(password.encode("utf-16-le"))
+            dklen=32,
+        )
     )


### PR DESCRIPTION
Cryptography uses rust as engine. This can lead to trouble when trying to build this package for arm/v7 as cryptography as no prebuilt binaries for this platform. In general, this will help with cross compatibility across architectures. Also it was needed, when i tried to build a docker image of an app using xknxproject as a lib. cross building for linux/arm/v7 would always fail in this case due to having to setup a rust compiler and not succeeding to do so.